### PR TITLE
Migrate to Github action/upload v4

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -77,7 +77,7 @@ jobs:
       run: echo "WHEEL_FILE=$(ls dist/*-py3-none-any.whl)" >> $GITHUB_ENV
 
     - name: Store artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ env.WHEEL_FILE }}
 


### PR DESCRIPTION
Following V2 deprecation. Migration guide [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md)